### PR TITLE
Remove super calls in Mac MvxApplicationDelegate

### DIFF
--- a/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
+++ b/MvvmCross/Platforms/Mac/Core/MvxApplicationDelegate.cs
@@ -37,7 +37,6 @@ namespace MvvmCross.Platforms.Mac.Core
             RunAppStart(notification);
 
             FireLifetimeChanged(MvxLifetimeEvent.Launching);
-            base.DidFinishLaunching(notification);
         }
 
         protected virtual void RunAppStart(object hint = null)
@@ -65,7 +64,6 @@ namespace MvvmCross.Platforms.Mac.Core
         public override void WillTerminate(Foundation.NSNotification notification)
         {
             FireLifetimeChanged(MvxLifetimeEvent.Closing);
-            base.WillTerminate(notification);
         }
 
         private void FireLifetimeChanged(MvxLifetimeEvent which)


### PR DESCRIPTION
Base calls for DidFinishLaunching/WillTerminate throw and shouldn't be used.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Application crashes on startup due to call to base.DidFinishLaunching

### :new: What is the new behavior (if this is a feature change)?
Application successfully starts up

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run a sample mac app, test if starts successfully or not

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [X] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [X] Rebased onto current develop